### PR TITLE
Include the Xbox 360 driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Include Xbox 360 gamepad driver kernel module [Laurence]
+
 # v2.12.5+rev6
 ## (2018-04-09)
 

--- a/layers/meta-resin-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-resin-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -6,7 +6,7 @@ SRC_URI_append = " \
     file://tegra186-tx2-cti-ASG916.dtb \
     "
 
-RESIN_CONFIGS_append = " compat spi"
+RESIN_CONFIGS_append = " compat spi gamepad"
 RESIN_CONFIGS_remove = "brcmfmac"
 
 RESIN_CONFIGS[compat] = " \
@@ -21,6 +21,14 @@ RESIN_CONFIGS[spi] = " \
 RESIN_CONFIGS_DEPS[spi] = " \
 		CONFIG_QSPI_TEGRA186=y \
 		CONFIG_SPI_TEGRA144=y \
+		"
+
+RESIN_CONFIGS[gamepad] = " \
+		CONFIG_JOYSTICK_XPAD=m \
+		"
+RESIN_CONFIGS_DEPS[gamepad] = " \
+		CONFIG_INPUT_JOYSTICK=y \
+		CONFIG_USB_ARCH_HAS_HCD=y \
 		"
 
 RESIN_CONFIGS_append_skx2 = " cdc_acm wdm"


### PR DESCRIPTION
The xpad driver is not included in the Linux 4 Tegra kernel config, but it is very useful for controlling robots

This PR adds the necessary config flags to the linux-tegra bbappend file so that xpad is built into the kernel