### PR TITLE
Remove kernel image

### DIFF
--- a/layers/meta-resin-jetson/recipes-core/images/resin-image.inc
+++ b/layers/meta-resin-jetson/recipes-core/images/resin-image.inc
@@ -11,3 +11,7 @@ RESIN_BOOT_SIZE = "80960"
 PARTITION_TABLE_TYPE = "gpt"
 
 IMAGE_INSTALL_append = " tegra186-flash-dry"
+
+# kernel-image is installed by meta-tegra. We use kernel-image-initramfs
+# Remove kernel-image package
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_remove = "kernel-image"


### PR DESCRIPTION
kernel-image-initramfs is being included into meta-resin by https://github.com/resin-os/meta-resin/pull/1153

The kernel-image package inherited by meta-tegra conflicts with it as the destination install path is the same.

Remove kernel-image